### PR TITLE
Dev

### DIFF
--- a/doc/Adapt_C_matrices_for_versions4&5.ipynb
+++ b/doc/Adapt_C_matrices_for_versions4&5.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For ecoinvent3.4 and ecoinvent3.5, the LCIA_implmentation.xls file does not include units for emissions of the pollutants anymore. This is a requirement however, in ecopold2matrix. This notebook introduces these units for emissions based on previous LCIA_implementation.xls files (e.g., based on ecoinvent3.3)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook relies on pandas to import and manipulate data from excel and requires the user to have access to LCIA_implementation files for ecoinvent3.4 or 3.5 that they want to ready for ecospold2matrix, as well as an old LCIA_implementation_file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "old_LCIA = pd.read_excel('put_the_path_to_your_old_LCIA_implementation_file.xls_here','CFs')\n",
+    "incomplete_LCIA = pd.read_excel('put_the_path_to_your_incomplete_LCIA_implementation_file.xls_here','CFs')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "complete_LCIA = incomplete_LCIA.merge(old_LCIA,how='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# drop obsolete columns\n",
+    "complete_LCIA = complete_LCIA.drop([i for i in old_LCIA.columns if i not in incomplete_LCIA.columns \n",
+    "                                    and i != 'exchange unit'],axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pollutants which were already present in your old version will have their exchange unit introduced in the incomplete_LCIA. New pollutants of the recent LCIA_implementation file however, will still have NaN as their unit (i.e., no unit specified)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# m2*year for land use/land occupation categories\n",
+    "complete_LCIA.loc[[i for i in complete_LCIA.index if 'land' in complete_LCIA.category[i]\n",
+    "                 and type(complete_LCIA.loc[i,'exchange unit']) == float],'exchange unit'] = 'm2*year'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# kBq for pollutant linked to radioactivity\n",
+    "complete_LCIA.loc[[i for i in complete_LCIA.index if (complete_LCIA.category[i] == 'ionising radiation'\n",
+    "                   or complete_LCIA.category[i] == 'radioactive waste to deposit')\n",
+    "                   and type(complete_LCIA.loc[i,'exchange unit']) == float],'exchange unit'] = 'kBq'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# m3 for amounts of water\n",
+    "complete_LCIA.loc[[i for i in complete_LCIA.index if complete_LCIA.category[i] == 'water depletion'\n",
+    "                 and type(complete_LCIA.loc[i,'exchange unit']) == float],'exchange unit'] = 'm3'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# kg for the rest\n",
+    "complete_LCIA.loc[[i for i in complete_LCIA.index if type(complete_LCIA.loc[i,'exchange unit']) == float],\n",
+    "                  'exchange unit'] = 'kg'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Export the completed version of the LCIA_implmentation file where you want (e.g., in your ecoinvent folder with datasets and MasterData)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "complete_LCIA.to_excel('put_the_path_where_you_want_this_completed_version_to_be_stored.xls')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ecospold2matrix/ecospold2matrix.py
+++ b/ecospold2matrix/ecospold2matrix.py
@@ -21,7 +21,7 @@ Credits:
     271:7e67a75ed791; Wed Sep 10; published under BDS-license:
 
         Copyright (c) 2014, Chris Mutel and ETH Zurich
-        Neither the name of ETH Zürich nor the names of its contributors may be
+        Neither the name of ETH Zurich nor the names of its contributors may be
         used to endorse or promote products derived from this software without
         specific prior written permission.  THIS SOFTWARE IS PROVIDED BY THE
         COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
@@ -1535,6 +1535,8 @@ class Ecospold2Matrix(object):
 
 
         self.PRO = self.PRO.reset_index()
+
+        del self.products.index.name
 
         # add data from self.products
         self.PRO = self.PRO.merge(self.products,


### PR DESCRIPTION
Added a notebook to documentation, enabling the modification of ecoinvent3.4 and 3.5's LCIA_implementation files, as, for whatever reason, they do not contain exchange units for pollutants. These units are a requirement in the current version of ecospold2matrix (maybe will become obsolete if the code is adapted), which made it impossible so far to parse the characterization matrix for ecoinvent3.4 and 3.5.